### PR TITLE
Upgrade to TS 5.1.6

### DIFF
--- a/src/compiler/_namespaces/ts.ts
+++ b/src/compiler/_namespaces/ts.ts
@@ -29,6 +29,7 @@ export * from "../moduleNameResolver";
 export * from "../binder";
 export * from "../symbolWalker";
 export * from "../checker";
+export * as deno from "../deno";
 export * from "../visitorPublic";
 export * from "../sourcemap";
 export * from "../transformers/utilities";

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -258,7 +258,7 @@ export namespace BuilderState {
         }
 
         // From ambient modules
-        for (const ambientModule of program.getTypeChecker().getAmbientModules()) {
+        for (const ambientModule of program.getTypeChecker().getAmbientModules(sourceFile)) {
             if (ambientModule.declarations && ambientModule.declarations.length > 1) {
                 addReferenceFromAmbientModule(ambientModule);
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -130,9 +130,9 @@ import {
     deduplicate,
     DefaultClause,
     defaultMaximumTruncationLength,
-    deno,
     DeferredTypeReference,
     DeleteExpression,
+    deno,
     Diagnostic,
     DiagnosticAndArguments,
     DiagnosticArguments,
@@ -2613,7 +2613,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (isGlobalScopeAugmentation(moduleAugmentation)) {
-            denoContext.mergeGlobalSymbolTable(moduleAugmentation, moduleAugmentation.symbol.exports!)
+            denoContext.mergeGlobalSymbolTable(moduleAugmentation, moduleAugmentation.symbol.exports!);
         }
         else {
             // find a module that about to be augmented
@@ -4869,10 +4869,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         // deno: attempt to resolve an npm package reference to its bare specifier w/ path ambient module
         // when not found and the symbol has zero exports
-        if (moduleReference.startsWith("npm:") && (result == null || result?.exports?.size === 0)) {
+        if (moduleReference.startsWith("npm:") && (result === undefined || result?.exports?.size === 0)) {
             const npmPackageRef = deno.tryParseNpmPackageReference(moduleReference);
             if (npmPackageRef) {
-                const bareSpecifier = npmPackageRef.name + (npmPackageRef.subPath == null ? "" : "/" + npmPackageRef.subPath);
+                const bareSpecifier = npmPackageRef.name + (npmPackageRef.subPath === undefined ? "" : "/" + npmPackageRef.subPath);
                 const ambientModule = tryFindAmbientModule(bareSpecifier, /*withAugmentations*/ true);
                 if (ambientModule) {
                     return ambientModule;
@@ -5863,7 +5863,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return result;
             }
             const globalSymbol = symbols === nodeGlobals ? nodeGlobalThisSymbol : symbols === globals ? globalThisSymbol : undefined;
-            return globalSymbol != null ? getCandidateListForSymbol(globalSymbol, globalSymbol, ignoreQualification) : undefined;
+            return globalSymbol !== undefined ? getCandidateListForSymbol(globalSymbol, globalSymbol, ignoreQualification) : undefined;
         }
 
         function getCandidateListForSymbol(symbolFromSymbolTable: Symbol, resolvedImportedSymbol: Symbol, ignoreQualification: boolean | undefined) {
@@ -48800,7 +48800,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 nodeAmbientModulesCache = getAmbientModules(denoContext.combinedGlobals);
             }
             return nodeAmbientModulesCache;
-        } else {
+        }
+        else {
             if (!ambientModulesCache) {
                 ambientModulesCache = getAmbientModules(globals);
             }
@@ -48808,14 +48809,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         function getAmbientModules(envGlobals: SymbolTable) {
-            const cache: Symbol[] = [];
+            const result: Symbol[] = [];
             envGlobals.forEach((global, sym) => {
                 // No need to `unescapeLeadingUnderscores`, an escaped symbol is never an ambient module.
                 if (ambientModuleSymbolRegex.test(sym as string)) {
-                    cache!.push(global);
+                    result.push(global);
                 }
             });
-            return cache;
+            return result;
         }
     }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -161,6 +161,8 @@ const libEntries: [string, string][] = [
     // Host only
     ["dom", "lib.dom.d.ts"],
     ["dom.iterable", "lib.dom.iterable.d.ts"],
+    ["dom.asynciterable", "lib.dom.asynciterable.d.ts"],
+    ["dom.extras", "lib.dom.extras.d.ts"],
     ["webworker", "lib.webworker.d.ts"],
     ["webworker.importscripts", "lib.webworker.importscripts.d.ts"],
     ["webworker.iterable", "lib.webworker.iterable.d.ts"],
@@ -211,7 +213,7 @@ const libEntries: [string, string][] = [
     ["es2022.string", "lib.es2022.string.d.ts"],
     ["es2022.regexp", "lib.es2022.regexp.d.ts"],
     ["es2023.array", "lib.es2023.array.d.ts"],
-    ["esnext.array", "lib.es2023.array.d.ts"],
+    ["esnext.array", "lib.esnext.array.d.ts"],
     ["esnext.symbol", "lib.es2019.symbol.d.ts"],
     ["esnext.asynciterable", "lib.es2018.asynciterable.d.ts"],
     ["esnext.intl", "lib.esnext.intl.d.ts"],

--- a/src/compiler/deno.ts
+++ b/src/compiler/deno.ts
@@ -1,0 +1,190 @@
+import * as ts from "./_namespaces/ts";
+
+export type IsNodeSourceFileCallback = (sourceFile: ts.SourceFile) => boolean;
+
+let isNodeSourceFile: IsNodeSourceFileCallback = () => false;
+let nodeBuiltInModuleNames = new Set<string>();
+let nodeOnlyGlobalNames = new Set<ts.__String>();
+
+export function setIsNodeSourceFileCallback(callback: IsNodeSourceFileCallback) {
+  isNodeSourceFile = callback;
+}
+
+export function setNodeBuiltInModuleNames(names: readonly string[]) {
+  nodeBuiltInModuleNames = new Set(names);
+}
+
+export function setNodeOnlyGlobalNames(names: readonly string[]) {
+  nodeBuiltInModuleNames = new Set(names);
+  nodeOnlyGlobalNames = new Set(names) as Set<ts.__String>;
+}
+
+// When upgrading:
+// Inspect all usages of "globals" and "globalThisSymbol" in checker.ts
+//  - Beware that `globalThisType` might refer to the global `this` type
+//    and not the global `globalThis` type
+
+export function createDenoForkContext({
+  mergeSymbol,
+  globals,
+  nodeGlobals,
+  ambientModuleSymbolRegex,
+}: {
+  mergeSymbol(target: ts.Symbol, source: ts.Symbol, unidirectional?: boolean): ts.Symbol;
+  globals: ts.SymbolTable;
+  nodeGlobals: ts.SymbolTable;
+  ambientModuleSymbolRegex: RegExp,
+}) {
+  return {
+    hasNodeSourceFile,
+    getGlobalsForName,
+    mergeGlobalSymbolTable,
+    combinedGlobals: createNodeGlobalsSymbolTable(),
+  };
+
+  function hasNodeSourceFile(node: ts.Node | undefined) {
+    if (!node) return false;
+    const sourceFile = ts.getSourceFileOfNode(node);
+    return isNodeSourceFile(sourceFile);
+  }
+
+  function getGlobalsForName(id: ts.__String) {
+    // Node ambient modules are only accessible in the node code,
+    // so put them on the node globals
+    if (ambientModuleSymbolRegex.test(id as string)) {
+      if ((id as string).startsWith('"node:')) {
+        // check if it's a node specifier that we support
+        const name = (id as string).slice(6, -1);
+        if (nodeBuiltInModuleNames.has(name)) {
+          return globals;
+        }
+      }
+      return nodeGlobals;
+    }
+    return nodeOnlyGlobalNames.has(id) ? nodeGlobals : globals;
+  }
+
+  function mergeGlobalSymbolTable(node: ts.Node, source: ts.SymbolTable, unidirectional = false) {
+    const sourceFile = ts.getSourceFileOfNode(node);
+    const isNodeFile = hasNodeSourceFile(sourceFile);
+    source.forEach((sourceSymbol, id) => {
+      const target = isNodeFile ? getGlobalsForName(id) : globals;
+      const targetSymbol = target.get(id);
+      target.set(id, targetSymbol ? mergeSymbol(targetSymbol, sourceSymbol, unidirectional) : sourceSymbol);
+    });
+  }
+
+  function createNodeGlobalsSymbolTable() {
+    return new Proxy(globals, {
+      get(target, prop: string | symbol, receiver) {
+        if (prop === "get") {
+          return (key: ts.__String) => {
+            return nodeGlobals.get(key) ?? globals.get(key);
+          };
+        } else if (prop === "has") {
+          return (key: ts.__String) => {
+            return nodeGlobals.has(key) || globals.has(key);
+          };
+        } else if (prop === "size") {
+          let i = 0;
+          for (const _ignore of getEntries(entry => entry)) {
+            i++;
+          }
+          return i;
+        } else if (prop === "forEach") {
+          return (action: (value: ts.Symbol, key: ts.__String) => void) => {
+            for (const [key, value] of getEntries(entry => entry)) {
+              action(value, key);
+            }
+          };
+        } else if (prop === "entries") {
+          return () => {
+            return getEntries(kv => kv);
+          };
+        } else if (prop === "keys") {
+          return () => {
+            return getEntries(kv => kv[0]);
+          };
+        } else if (prop === "values") {
+          return () => {
+            return getEntries(kv => kv[1]);
+          };
+        } else if (prop === Symbol.iterator) {
+          return () => {
+            // Need to convert this to an array since typescript targets ES5
+            // and providing back the iterator won't work here. I don't want
+            // to change the target to ES6 because I'm not sure if that would
+            // surface any issues.
+            return Array.from(getEntries(kv => kv))[Symbol.iterator]();
+          };
+        } else {
+          const value = (target as any)[prop];
+          if (value instanceof Function) {
+            return function (this: any, ...args: any[]) {
+              return value.apply(this === receiver ? target : this, args);
+            };
+          }
+          return value;
+        }
+      },
+    });
+
+    function* getEntries<R>(
+      transform: (value: [ts.__String, ts.Symbol]) => R
+    ) {
+      const foundKeys = new Set<ts.__String>();
+      // prefer the node globals over the deno globalThis
+      for (const entries of [nodeGlobals.entries(), globals.entries()]) {
+        for (const entry of entries) {
+          if (!foundKeys.has(entry[0])) {
+            yield transform(entry);
+            foundKeys.add(entry[0]);
+          }
+        }
+      }
+    }
+  }
+}
+
+export interface NpmPackageReference {
+  name: string;
+  versionReq: string;
+  subPath: string | undefined;
+}
+
+export function tryParseNpmPackageReference(text: string) {
+  try {
+    return parseNpmPackageReference(text);
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseNpmPackageReference(text: string) {
+  if (!text.startsWith("npm:")) {
+    throw new Error(`Not an npm specifier: ${text}`);
+  }
+  text = text.replace(/^npm:\/?/, ""); // todo: remove this regex
+  const parts = text.split("/");
+  const namePartLen = text.startsWith("@") ? 2 : 1;
+  if (parts.length < namePartLen) {
+    throw new Error(`Not a valid package: ${text}`);
+  }
+  const nameParts = parts.slice(0, namePartLen);
+  const lastNamePart = nameParts.at(-1)!;
+  const lastAtIndex = lastNamePart.lastIndexOf("@");
+  let versionReq: string | undefined = undefined;
+  if (lastAtIndex > 0) {
+    versionReq = lastNamePart.substring(lastAtIndex + 1);
+    nameParts[nameParts.length - 1] = lastNamePart.substring(0, lastAtIndex);
+  }
+  const name = nameParts.join("/");
+  if (name.length === 0) {
+    throw new Error(`Npm specifier did not have a name: ${text}`);
+  }
+  return {
+    name,
+    versionReq,
+    subPath: parts.length > nameParts.length ? parts.slice(nameParts.length).join("/") : undefined,
+  };
+}

--- a/src/compiler/deno.ts
+++ b/src/compiler/deno.ts
@@ -81,35 +81,42 @@ export function createDenoForkContext({
           return (key: ts.__String) => {
             return nodeGlobals.get(key) ?? globals.get(key);
           };
-        } else if (prop === "has") {
+        }
+        else if (prop === "has") {
           return (key: ts.__String) => {
             return nodeGlobals.has(key) || globals.has(key);
           };
-        } else if (prop === "size") {
+        }
+        else if (prop === "size") {
           let i = 0;
           for (const _ignore of getEntries(entry => entry)) {
             i++;
           }
           return i;
-        } else if (prop === "forEach") {
+        }
+        else if (prop === "forEach") {
           return (action: (value: ts.Symbol, key: ts.__String) => void) => {
             for (const [key, value] of getEntries(entry => entry)) {
               action(value, key);
             }
           };
-        } else if (prop === "entries") {
+        }
+        else if (prop === "entries") {
           return () => {
             return getEntries(kv => kv);
           };
-        } else if (prop === "keys") {
+        }
+        else if (prop === "keys") {
           return () => {
             return getEntries(kv => kv[0]);
           };
-        } else if (prop === "values") {
+        }
+        else if (prop === "values") {
           return () => {
             return getEntries(kv => kv[1]);
           };
-        } else if (prop === Symbol.iterator) {
+        }
+        else if (prop === Symbol.iterator) {
           return () => {
             // Need to convert this to an array since typescript targets ES5
             // and providing back the iterator won't work here. I don't want
@@ -117,7 +124,8 @@ export function createDenoForkContext({
             // surface any issues.
             return Array.from(getEntries(kv => kv))[Symbol.iterator]();
           };
-        } else {
+        }
+        else {
           const value = (target as any)[prop];
           if (value instanceof Function) {
             return function (this: any, ...args: any[]) {
@@ -155,7 +163,8 @@ export interface NpmPackageReference {
 export function tryParseNpmPackageReference(text: string) {
   try {
     return parseNpmPackageReference(text);
-  } catch {
+  }
+  catch {
     return undefined;
   }
 }
@@ -173,7 +182,7 @@ export function parseNpmPackageReference(text: string) {
   const nameParts = parts.slice(0, namePartLen);
   const lastNamePart = nameParts.at(-1)!;
   const lastAtIndex = lastNamePart.lastIndexOf("@");
-  let versionReq: string | undefined = undefined;
+  let versionReq: string | undefined;
   if (lastAtIndex > 0) {
     versionReq = lastNamePart.substring(lastAtIndex + 1);
     nameParts[nameParts.length - 1] = lastNamePart.substring(0, lastAtIndex);

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -214,6 +214,11 @@ function getEncodedRootLength(path: string): number {
         return ~path.length; // URL: "file://server", "http://server"
     }
 
+    // deno: temporary hack until https://github.com/microsoft/TypeScript/issues/53605 is fixed
+    if (path.startsWith("data:")) {
+        return ~path.length;
+    }
+
     // relative
     return 0;
 }
@@ -704,6 +709,11 @@ export function ensureTrailingDirectorySeparator(path: string): string;
 /** @internal */
 export function ensureTrailingDirectorySeparator(path: string) {
     if (!hasTrailingDirectorySeparator(path)) {
+        // deno: added this so that data urls don't get a trailing slash
+        // https://github.com/microsoft/TypeScript/issues/53605#issuecomment-1492167313
+        if (path.startsWith("data:")) {
+            return path;
+        }
         return path + directorySeparator;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5109,7 +5109,7 @@ export interface TypeChecker {
     /** @internal */ forEachExportAndPropertyOfModule(moduleSymbol: Symbol, cb: (symbol: Symbol, key: __String) => void): void;
     getJsxIntrinsicTagNamesAt(location: Node): Symbol[];
     isOptionalParameter(node: ParameterDeclaration): boolean;
-    getAmbientModules(): Symbol[];
+    getAmbientModules(sourceFile?: SourceFile): Symbol[];
 
     tryGetMemberInModuleExports(memberName: string, moduleSymbol: Symbol): Symbol | undefined;
     /**

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5298,7 +5298,8 @@ function isProbablyGlobalType(type: Type, sourceFile: SourceFile, checker: TypeC
     if (globalSymbol && checker.getTypeOfSymbolAtLocation(globalSymbol, sourceFile) === type) {
         return true;
     }
-    const globalThisSymbol = checker.resolveName("globalThis", /*location*/ undefined, SymbolFlags.Value, /*excludeGlobals*/ false);
+    // deno: provide sourceFile so that it can figure out if it's a node or deno globalThis
+    const globalThisSymbol = checker.resolveName("globalThis", /*location*/ sourceFile, SymbolFlags.Value, /*excludeGlobals*/ false);
     if (globalThisSymbol && checker.getTypeOfSymbolAtLocation(globalThisSymbol, sourceFile) === type) {
         return true;
     }


### PR DESCRIPTION
Remotes:

* origin - https://github.com/dsherret/TypeScript
* denoland - https://github.com/denoland/TypeScript
* upstream - https://github.com/Microsoft/TypeScript

Actions:

1. Closed previous "Upgrade to TS 5.0.4" PR
1. Checked out upstream/release-5.1 and ensured it was on the commit of the release.
1. `git checkout -b branch_v5.1.6`
1. `git push denoland`
1. `git checkout -b branch_v5.1.6_patch`
1. Cherry picked changes in branch_v5.0.4_patch
1. `npm install && npx hereby` (to build)
1. Inspected all usages of "globals" and "globalThisSymbol" in checker.ts (being aware that `globalThisType` might refer to the global `this` type and not the global `globalThis` type)
1. Ran `gulp local`
1. Copied `built/local/typescript.js` to `../deno/cli/tsc/00_typescript.js`
1. Copied the .d.ts files from `built/local` to `../deno/cli/tsc/dts` as appropriate (all the ones currently in `deno/cli/tsc/dts`).
1. Reviewed this dts files and made any modifications (reverts) necessary
1. Opened this PR with base branch_v5.1.6

https://github.com/denoland/deno/tree/main/cli/tsc#how-to-upgrade-typescript