### PR TITLE
Upgrade to TS 5.2.2

### DIFF
--- a/src/compiler/_namespaces/ts.ts
+++ b/src/compiler/_namespaces/ts.ts
@@ -29,6 +29,7 @@ export * from "../moduleNameResolver";
 export * from "../binder";
 export * from "../symbolWalker";
 export * from "../checker";
+export * as deno from "../deno";
 export * from "../visitorPublic";
 export * from "../sourcemap";
 export * from "../transformers/utilities";

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -258,7 +258,7 @@ export namespace BuilderState {
         }
 
         // From ambient modules
-        for (const ambientModule of program.getTypeChecker().getAmbientModules()) {
+        for (const ambientModule of program.getTypeChecker().getAmbientModules(sourceFile)) {
             if (ambientModule.declarations && ambientModule.declarations.length > 1) {
                 addReferenceFromAmbientModule(ambientModule);
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -133,6 +133,7 @@ import {
     defaultMaximumTruncationLength,
     DeferredTypeReference,
     DeleteExpression,
+    deno,
     Diagnostic,
     DiagnosticAndArguments,
     DiagnosticArguments,
@@ -1456,6 +1457,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var nodeBuilder = createNodeBuilder();
 
     var globals = createSymbolTable();
+    var nodeGlobals = createSymbolTable();
     var undefinedSymbol = createSymbol(SymbolFlags.Property, "undefined" as __String);
     undefinedSymbol.declarations = [];
 
@@ -1463,6 +1465,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     globalThisSymbol.exports = globals;
     globalThisSymbol.declarations = [];
     globals.set(globalThisSymbol.escapedName, globalThisSymbol);
+
+    const denoContext = deno.createDenoForkContext({
+        globals,
+        nodeGlobals,
+        mergeSymbol,
+        ambientModuleSymbolRegex,
+    });
+
+    const nodeGlobalThisSymbol = createSymbol(SymbolFlags.Module, "globalThis" as __String, CheckFlags.Readonly);
+    nodeGlobalThisSymbol.exports = denoContext.combinedGlobals;
+    nodeGlobalThisSymbol.declarations = [];
+    nodeGlobals.set(nodeGlobalThisSymbol.escapedName, nodeGlobalThisSymbol);
 
     var argumentsSymbol = createSymbol(SymbolFlags.Property, "arguments" as __String);
     var requireSymbol = createSymbol(SymbolFlags.Property, "require" as __String);
@@ -2074,6 +2088,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var reverseMappedCache = new Map<string, Type | undefined>();
     var homomorphicMappedTypeInferenceStack: string[] = [];
     var ambientModulesCache: Symbol[] | undefined;
+    var nodeAmbientModulesCache: Symbol[] | undefined;
     /**
      * List of every ambient module with a "*" wildcard.
      * Unlike other ambient modules, these can't be stored in `globals` because symbol tables only deal with exact matches.
@@ -2526,7 +2541,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Do not report an error when merging `var globalThis` with the built-in `globalThis`,
             // as we will already report a "Declaration name conflicts..." error, and this error
             // won't make much sense.
-            if (target !== globalThisSymbol) {
+            if (target !== globalThisSymbol && target !== nodeGlobalThisSymbol) {
                 error(
                     source.declarations && getNameOfDeclaration(source.declarations[0]),
                     Diagnostics.Cannot_augment_module_0_with_value_exports_because_it_resolves_to_a_non_module_entity,
@@ -2620,7 +2635,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (isGlobalScopeAugmentation(moduleAugmentation)) {
-            mergeSymbolTable(globals, moduleAugmentation.symbol.exports!);
+            denoContext.mergeGlobalSymbolTable(moduleAugmentation, moduleAugmentation.symbol.exports!);
         }
         else {
             // find a module that about to be augmented
@@ -3378,7 +3393,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             if (!excludeGlobals) {
-                result = lookup(globals, name, meaning);
+                if (denoContext.hasNodeSourceFile(lastLocation)) {
+                    result = lookup(nodeGlobals, name, meaning);
+                }
+                if (!result) {
+                    result = lookup(globals, name, meaning);
+                }
             }
         }
         if (!result) {
@@ -3972,7 +3992,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const usageMode = file && getUsageModeForExpression(usage);
         if (file && usageMode !== undefined) {
             const result = isESMFormatImportImportingCommonjsFormatFile(usageMode, file.impliedNodeFormat);
-            if (usageMode === ModuleKind.ESNext || result) {
+            // deno: removed condition in typescript here (https://github.com/microsoft/TypeScript/issues/51321)
+            if (result) {
                 return result;
             }
             // fallthrough on cjs usages so we imply defaults for interop'd imports, too
@@ -4878,6 +4899,25 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function resolveExternalModule(location: Node, moduleReference: string, moduleNotFoundError: DiagnosticMessage | undefined, errorNode: Node, isForAugmentation = false): Symbol | undefined {
+        const result = resolveExternalModuleInner(location, moduleReference, moduleNotFoundError, errorNode, isForAugmentation);
+
+        // deno: attempt to resolve an npm package reference to its bare specifier w/ path ambient module
+        // when not found and the symbol has zero exports
+        if (moduleReference.startsWith("npm:") && (result === undefined || result?.exports?.size === 0)) {
+            const npmPackageRef = deno.tryParseNpmPackageReference(moduleReference);
+            if (npmPackageRef) {
+                const bareSpecifier = npmPackageRef.name + (npmPackageRef.subPath === undefined ? "" : "/" + npmPackageRef.subPath);
+                const ambientModule = tryFindAmbientModule(bareSpecifier, /*withAugmentations*/ true);
+                if (ambientModule) {
+                    return ambientModule;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    function resolveExternalModuleInner(location: Node, moduleReference: string, moduleNotFoundError: DiagnosticMessage | undefined, errorNode: Node, isForAugmentation = false): Symbol | undefined {
         if (startsWith(moduleReference, "@types/")) {
             const diag = Diagnostics.Cannot_import_type_declaration_files_Consider_importing_0_instead_of_1;
             const withoutAtTypePrefix = removePrefix(moduleReference, "@types/");
@@ -5757,6 +5797,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
 
+        if (denoContext.hasNodeSourceFile(enclosingDeclaration)) {
+            result = callback(nodeGlobals, /*ignoreQualification*/ undefined, /*isLocalNameLookup*/ true);
+            if (result) {
+                return result;
+            }
+        }
+
         return callback(globals, /*ignoreQualification*/ undefined, /*isLocalNameLookup*/ true);
     }
 
@@ -5851,7 +5898,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             });
 
             // If there's no result and we're looking at the global symbol table, treat `globalThis` like an alias and try to lookup thru that
-            return result || (symbols === globals ? getCandidateListForSymbol(globalThisSymbol, globalThisSymbol, ignoreQualification) : undefined);
+            if (result) {
+                return result;
+            }
+            const globalSymbol = symbols === nodeGlobals ? nodeGlobalThisSymbol : symbols === globals ? globalThisSymbol : undefined;
+            return globalSymbol !== undefined ? getCandidateListForSymbol(globalSymbol, globalSymbol, ignoreQualification) : undefined;
         }
 
         function getCandidateListForSymbol(symbolFromSymbolTable: Symbol, resolvedImportedSymbol: Symbol, ignoreQualification: boolean | undefined) {
@@ -13100,7 +13151,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Combinations of function, class, enum and module
         let members = getExportsOfSymbol(symbol);
         let indexInfos: IndexInfo[] | undefined;
-        if (symbol === globalThisSymbol) {
+        if (symbol === globalThisSymbol || symbol === nodeGlobalThisSymbol) {
             const varsOnly = new Map<__String, Symbol>();
             members.forEach(p => {
                 if (!(p.flags & SymbolFlags.BlockScoped) && !(p.flags & SymbolFlags.ValueModule && p.declarations?.length && every(p.declarations, isAmbientModule))) {
@@ -14453,7 +14504,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isExternalModuleNameRelative(moduleName)) {
             return undefined;
         }
-        const symbol = getSymbol(globals, '"' + moduleName + '"' as __String, SymbolFlags.ValueModule);
+        const symbol = getSymbol(denoContext.combinedGlobals, '"' + moduleName + '"' as __String, SymbolFlags.ValueModule);
         // merged symbol is module declaration symbol combined with all augmentations
         return symbol && withAugmentations ? getMergedSymbol(symbol) : symbol;
     }
@@ -17478,6 +17529,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
 
                 if (objectType.symbol === globalThisSymbol && propName !== undefined && globalThisSymbol.exports!.has(propName) && (globalThisSymbol.exports!.get(propName)!.flags & SymbolFlags.BlockScoped)) {
+                    error(accessExpression, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(propName), typeToString(objectType));
+                }
+                // deno: ensure condition and body match the above
+                else if (objectType.symbol === nodeGlobalThisSymbol && propName !== undefined && nodeGlobalThisSymbol.exports!.has(propName) && (nodeGlobalThisSymbol.exports!.get(propName)!.flags & SymbolFlags.BlockScoped)) {
                     error(accessExpression, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(propName), typeToString(objectType));
                 }
                 else if (noImplicitAny && !compilerOptions.suppressImplicitAnyIndexErrors && !(accessFlags & AccessFlags.SuppressNoImplicitAnyError)) {
@@ -28363,7 +28418,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const type = tryGetThisTypeAt(node, /*includeGlobalThis*/ true, container);
         if (noImplicitThis) {
             const globalThisType = getTypeOfSymbol(globalThisSymbol);
-            if (type === globalThisType && capturedByArrowFunction) {
+            if ((type === globalThisType || type === getTypeOfSymbol(nodeGlobalThisSymbol)) && capturedByArrowFunction) {
                 error(node, Diagnostics.The_containing_arrow_function_captures_the_global_value_of_this);
             }
             else if (!type) {
@@ -28423,6 +28478,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return undefinedType;
             }
             else if (includeGlobalThis) {
+                if (denoContext.hasNodeSourceFile(container)) {
+                    return getTypeOfSymbol(nodeGlobalThisSymbol);
+                }
                 return getTypeOfSymbol(globalThisSymbol);
             }
         }
@@ -31634,6 +31692,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     return anyType;
                 }
+                // deno: ensure condition matches above
+                if (leftType.symbol === nodeGlobalThisSymbol) {
+                    // deno: don't bother with errors like above for simplicity
+                    return anyType;
+                }
                 if (right.escapedText && !checkAndReportErrorForExtendingInterface(node)) {
                     reportNonexistentProperty(right, isThisTypeParameter(leftType) ? apparentType : leftType, isUncheckedJS);
                 }
@@ -31956,7 +32019,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // However, resolveNameHelper will continue and call this callback again, so we'll eventually get a correct suggestion.
             if (symbol) return symbol;
             let candidates: Symbol[];
-            if (symbols === globals) {
+            if (symbols === globals || symbols === nodeGlobals) {
                 const primitives = mapDefined(
                     ["string", "number", "boolean", "object", "bigint", "symbol"],
                     s => symbols.has((s.charAt(0).toUpperCase() + s.slice(1)) as __String)
@@ -44641,7 +44704,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // find immediate value referenced by exported name (SymbolFlags.Alias is set so we don't chase down aliases)
             const symbol = resolveName(exportedName, exportedName.escapedText, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias,
                 /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined, /*isUse*/ true);
-            if (symbol && (symbol === undefinedSymbol || symbol === globalThisSymbol || symbol.declarations && isGlobalSourceFile(getDeclarationContainer(symbol.declarations[0])))) {
+            if (symbol && (symbol === undefinedSymbol || symbol === globalThisSymbol || symbol === nodeGlobalThisSymbol || symbol.declarations && isGlobalSourceFile(getDeclarationContainer(symbol.declarations[0])))) {
                 error(exportedName, Diagnostics.Cannot_export_0_Only_local_declarations_can_be_exported_from_a_module, idText(exportedName));
             }
             else {
@@ -44749,7 +44812,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (node.isExportEquals) {
             // Forbid export= in esm implementation files, and esm mode declaration files
             if (moduleKind >= ModuleKind.ES2015 &&
-                ((node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext) ||
+                // deno: temporarily disable this one until Deno 2.0 (https://github.com/microsoft/TypeScript/pull/52109)
+                (/* (node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext) || */
                 (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))) {
                 // export assignment is not supported in es6 modules
                 grammarErrorOnNode(node, Diagnostics.Export_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_export_default_or_another_module_format_instead);
@@ -45437,6 +45501,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                 isStaticSymbol = isStatic(location);
                 location = location.parent;
+            }
+
+            if (denoContext.hasNodeSourceFile(location)) {
+                copySymbols(nodeGlobals, meaning);
             }
 
             copySymbols(globals, meaning);
@@ -46650,6 +46718,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function hasGlobalName(name: string): boolean {
+        // deno: seems ok not to bother with nodeGlobals here since
+        // this is just a public api function that we don't bother with
+        // NOTICE: Make sure to check that's still the case when upgrading!!
         return globals.has(escapeLeadingUnderscores(name));
     }
 
@@ -47061,10 +47132,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         diagnostics.add(createDiagnosticForNode(declaration, Diagnostics.Declaration_name_conflicts_with_built_in_global_identifier_0, "globalThis"));
                     }
                 }
-                mergeSymbolTable(globals, file.locals!);
+                denoContext.mergeGlobalSymbolTable(file, file.locals!);
             }
             if (file.jsGlobalAugmentations) {
-                mergeSymbolTable(globals, file.jsGlobalAugmentations);
+                denoContext.mergeGlobalSymbolTable(file, file.jsGlobalAugmentations);
             }
             if (file.patternAmbientModules && file.patternAmbientModules.length) {
                 patternAmbientModules = concatenate(patternAmbientModules, file.patternAmbientModules);
@@ -47075,9 +47146,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (file.symbol && file.symbol.globalExports) {
                 // Merge in UMD exports with first-in-wins semantics (see #9771)
                 const source = file.symbol.globalExports;
+                const isNodeFile = denoContext.hasNodeSourceFile(file);
                 source.forEach((sourceSymbol, id) => {
-                    if (!globals.has(id)) {
-                        globals.set(id, sourceSymbol);
+                    const envGlobals = isNodeFile ? denoContext.getGlobalsForName(id) : globals;
+                    if (!envGlobals.has(id)) {
+                        envGlobals.set(id, sourceSymbol);
                     }
                 });
             }
@@ -47107,6 +47180,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getSymbolLinks(argumentsSymbol).type = getGlobalType("IArguments" as __String, /*arity*/ 0, /*reportErrors*/ true);
         getSymbolLinks(unknownSymbol).type = errorType;
         getSymbolLinks(globalThisSymbol).type = createObjectType(ObjectFlags.Anonymous, globalThisSymbol);
+        getSymbolLinks(nodeGlobalThisSymbol).type = createObjectType(ObjectFlags.Anonymous, nodeGlobalThisSymbol);
 
         // Initialize special types
         globalArrayType = getGlobalType("Array" as __String, /*arity*/ 1, /*reportErrors*/ true);
@@ -48976,17 +49050,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return false;
     }
 
-    function getAmbientModules(): Symbol[] {
-        if (!ambientModulesCache) {
-            ambientModulesCache = [];
-            globals.forEach((global, sym) => {
+    function getAmbientModules(sourceFile?: SourceFile): Symbol[] {
+        const isNode = denoContext.hasNodeSourceFile(sourceFile);
+        if (isNode) {
+            if (!nodeAmbientModulesCache) {
+                nodeAmbientModulesCache = getAmbientModules(denoContext.combinedGlobals);
+            }
+            return nodeAmbientModulesCache;
+        }
+        else {
+            if (!ambientModulesCache) {
+                ambientModulesCache = getAmbientModules(globals);
+            }
+            return ambientModulesCache;
+        }
+
+        function getAmbientModules(envGlobals: SymbolTable) {
+            const result: Symbol[] = [];
+            envGlobals.forEach((global, sym) => {
                 // No need to `unescapeLeadingUnderscores`, an escaped symbol is never an ambient module.
                 if (ambientModuleSymbolRegex.test(sym as string)) {
-                    ambientModulesCache!.push(global);
+                    result.push(global);
                 }
             });
+            return result;
         }
-        return ambientModulesCache;
     }
 
     function checkGrammarImportClause(node: ImportClause): boolean {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -161,6 +161,8 @@ const libEntries: [string, string][] = [
     // Host only
     ["dom", "lib.dom.d.ts"],
     ["dom.iterable", "lib.dom.iterable.d.ts"],
+    ["dom.asynciterable", "lib.dom.asynciterable.d.ts"],
+    ["dom.extras", "lib.dom.extras.d.ts"],
     ["webworker", "lib.webworker.d.ts"],
     ["webworker.importscripts", "lib.webworker.importscripts.d.ts"],
     ["webworker.iterable", "lib.webworker.iterable.d.ts"],
@@ -213,7 +215,7 @@ const libEntries: [string, string][] = [
     ["es2022.regexp", "lib.es2022.regexp.d.ts"],
     ["es2023.array", "lib.es2023.array.d.ts"],
     ["es2023.collection", "lib.es2023.collection.d.ts"],
-    ["esnext.array", "lib.es2023.array.d.ts"],
+    ["esnext.array", "lib.esnext.array.d.ts"],
     ["esnext.collection", "lib.es2023.collection.d.ts"],
     ["esnext.symbol", "lib.es2019.symbol.d.ts"],
     ["esnext.asynciterable", "lib.es2018.asynciterable.d.ts"],

--- a/src/compiler/deno.ts
+++ b/src/compiler/deno.ts
@@ -1,0 +1,199 @@
+import * as ts from "./_namespaces/ts";
+
+export type IsNodeSourceFileCallback = (sourceFile: ts.SourceFile) => boolean;
+
+let isNodeSourceFile: IsNodeSourceFileCallback = () => false;
+let nodeBuiltInModuleNames = new Set<string>();
+let nodeOnlyGlobalNames = new Set<ts.__String>();
+
+export function setIsNodeSourceFileCallback(callback: IsNodeSourceFileCallback) {
+  isNodeSourceFile = callback;
+}
+
+export function setNodeBuiltInModuleNames(names: readonly string[]) {
+  nodeBuiltInModuleNames = new Set(names);
+}
+
+export function setNodeOnlyGlobalNames(names: readonly string[]) {
+  nodeBuiltInModuleNames = new Set(names);
+  nodeOnlyGlobalNames = new Set(names) as Set<ts.__String>;
+}
+
+// When upgrading:
+// Inspect all usages of "globals" and "globalThisSymbol" in checker.ts
+//  - Beware that `globalThisType` might refer to the global `this` type
+//    and not the global `globalThis` type
+
+export function createDenoForkContext({
+  mergeSymbol,
+  globals,
+  nodeGlobals,
+  ambientModuleSymbolRegex,
+}: {
+  mergeSymbol(target: ts.Symbol, source: ts.Symbol, unidirectional?: boolean): ts.Symbol;
+  globals: ts.SymbolTable;
+  nodeGlobals: ts.SymbolTable;
+  ambientModuleSymbolRegex: RegExp,
+}) {
+  return {
+    hasNodeSourceFile,
+    getGlobalsForName,
+    mergeGlobalSymbolTable,
+    combinedGlobals: createNodeGlobalsSymbolTable(),
+  };
+
+  function hasNodeSourceFile(node: ts.Node | undefined) {
+    if (!node) return false;
+    const sourceFile = ts.getSourceFileOfNode(node);
+    return isNodeSourceFile(sourceFile);
+  }
+
+  function getGlobalsForName(id: ts.__String) {
+    // Node ambient modules are only accessible in the node code,
+    // so put them on the node globals
+    if (ambientModuleSymbolRegex.test(id as string)) {
+      if ((id as string).startsWith('"node:')) {
+        // check if it's a node specifier that we support
+        const name = (id as string).slice(6, -1);
+        if (nodeBuiltInModuleNames.has(name)) {
+          return globals;
+        }
+      }
+      return nodeGlobals;
+    }
+    return nodeOnlyGlobalNames.has(id) ? nodeGlobals : globals;
+  }
+
+  function mergeGlobalSymbolTable(node: ts.Node, source: ts.SymbolTable, unidirectional = false) {
+    const sourceFile = ts.getSourceFileOfNode(node);
+    const isNodeFile = hasNodeSourceFile(sourceFile);
+    source.forEach((sourceSymbol, id) => {
+      const target = isNodeFile ? getGlobalsForName(id) : globals;
+      const targetSymbol = target.get(id);
+      target.set(id, targetSymbol ? mergeSymbol(targetSymbol, sourceSymbol, unidirectional) : sourceSymbol);
+    });
+  }
+
+  function createNodeGlobalsSymbolTable() {
+    return new Proxy(globals, {
+      get(target, prop: string | symbol, receiver) {
+        if (prop === "get") {
+          return (key: ts.__String) => {
+            return nodeGlobals.get(key) ?? globals.get(key);
+          };
+        }
+        else if (prop === "has") {
+          return (key: ts.__String) => {
+            return nodeGlobals.has(key) || globals.has(key);
+          };
+        }
+        else if (prop === "size") {
+          let i = 0;
+          for (const _ignore of getEntries(entry => entry)) {
+            i++;
+          }
+          return i;
+        }
+        else if (prop === "forEach") {
+          return (action: (value: ts.Symbol, key: ts.__String) => void) => {
+            for (const [key, value] of getEntries(entry => entry)) {
+              action(value, key);
+            }
+          };
+        }
+        else if (prop === "entries") {
+          return () => {
+            return getEntries(kv => kv);
+          };
+        }
+        else if (prop === "keys") {
+          return () => {
+            return getEntries(kv => kv[0]);
+          };
+        }
+        else if (prop === "values") {
+          return () => {
+            return getEntries(kv => kv[1]);
+          };
+        }
+        else if (prop === Symbol.iterator) {
+          return () => {
+            // Need to convert this to an array since typescript targets ES5
+            // and providing back the iterator won't work here. I don't want
+            // to change the target to ES6 because I'm not sure if that would
+            // surface any issues.
+            return Array.from(getEntries(kv => kv))[Symbol.iterator]();
+          };
+        }
+        else {
+          const value = (target as any)[prop];
+          if (value instanceof Function) {
+            return function (this: any, ...args: any[]) {
+              return value.apply(this === receiver ? target : this, args);
+            };
+          }
+          return value;
+        }
+      },
+    });
+
+    function* getEntries<R>(
+      transform: (value: [ts.__String, ts.Symbol]) => R
+    ) {
+      const foundKeys = new Set<ts.__String>();
+      // prefer the node globals over the deno globalThis
+      for (const entries of [nodeGlobals.entries(), globals.entries()]) {
+        for (const entry of entries) {
+          if (!foundKeys.has(entry[0])) {
+            yield transform(entry);
+            foundKeys.add(entry[0]);
+          }
+        }
+      }
+    }
+  }
+}
+
+export interface NpmPackageReference {
+  name: string;
+  versionReq: string;
+  subPath: string | undefined;
+}
+
+export function tryParseNpmPackageReference(text: string) {
+  try {
+    return parseNpmPackageReference(text);
+  }
+  catch {
+    return undefined;
+  }
+}
+
+export function parseNpmPackageReference(text: string) {
+  if (!text.startsWith("npm:")) {
+    throw new Error(`Not an npm specifier: ${text}`);
+  }
+  text = text.replace(/^npm:\/?/, ""); // todo: remove this regex
+  const parts = text.split("/");
+  const namePartLen = text.startsWith("@") ? 2 : 1;
+  if (parts.length < namePartLen) {
+    throw new Error(`Not a valid package: ${text}`);
+  }
+  const nameParts = parts.slice(0, namePartLen);
+  const lastNamePart = nameParts.at(-1)!;
+  const lastAtIndex = lastNamePart.lastIndexOf("@");
+  let versionReq: string | undefined;
+  if (lastAtIndex > 0) {
+    versionReq = lastNamePart.substring(lastAtIndex + 1);
+    nameParts[nameParts.length - 1] = lastNamePart.substring(0, lastAtIndex);
+  }
+  const name = nameParts.join("/");
+  if (name.length === 0) {
+    throw new Error(`Npm specifier did not have a name: ${text}`);
+  }
+  return {
+    name,
+    versionReq,
+    subPath: parts.length > nameParts.length ? parts.slice(nameParts.length).join("/") : undefined,
+  };
+}

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8284,7 +8284,8 @@ namespace Parser {
         const moduleSpecifier = parseModuleSpecifier();
 
         let assertClause: AssertClause | undefined;
-        if (token() === SyntaxKind.AssertKeyword && !scanner.hasPrecedingLineBreak()) {
+        const hasAssertKeyword = token() === SyntaxKind.AssertKeyword || token() === SyntaxKind.WithKeyword;
+        if (hasAssertKeyword && !scanner.hasPrecedingLineBreak()) {
             assertClause = parseAssertClause();
         }
 
@@ -8304,7 +8305,11 @@ namespace Parser {
     function parseAssertClause(skipAssertKeyword?: true) {
         const pos = getNodePos();
         if (!skipAssertKeyword) {
-            parseExpected(SyntaxKind.AssertKeyword);
+            if (token() === SyntaxKind.WithKeyword) {
+                parseExpected(SyntaxKind.WithKeyword);
+            } else {
+                parseExpected(SyntaxKind.AssertKeyword);
+            }
         }
         const openBracePosition = scanner.getTokenStart();
         if (parseExpected(SyntaxKind.OpenBraceToken)) {

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -214,6 +214,11 @@ function getEncodedRootLength(path: string): number {
         return ~path.length; // URL: "file://server", "http://server"
     }
 
+    // deno: temporary hack until https://github.com/microsoft/TypeScript/issues/53605 is fixed
+    if (path.startsWith("data:")) {
+        return ~path.length;
+    }
+
     // relative
     return 0;
 }
@@ -704,6 +709,11 @@ export function ensureTrailingDirectorySeparator(path: string): string;
 /** @internal */
 export function ensureTrailingDirectorySeparator(path: string) {
     if (!hasTrailingDirectorySeparator(path)) {
+        // deno: added this so that data urls don't get a trailing slash
+        // https://github.com/microsoft/TypeScript/issues/53605#issuecomment-1492167313
+        if (path.startsWith("data:")) {
+            return path;
+        }
         return path + directorySeparator;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5115,7 +5115,7 @@ export interface TypeChecker {
     /** @internal */ forEachExportAndPropertyOfModule(moduleSymbol: Symbol, cb: (symbol: Symbol, key: __String) => void): void;
     getJsxIntrinsicTagNamesAt(location: Node): Symbol[];
     isOptionalParameter(node: ParameterDeclaration): boolean;
-    getAmbientModules(): Symbol[];
+    getAmbientModules(sourceFile?: SourceFile): Symbol[];
 
     tryGetMemberInModuleExports(memberName: string, moduleSymbol: Symbol): Symbol | undefined;
     /**

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -621,6 +621,7 @@ interface ImportMeta {
  */
 interface ImportCallOptions {
     assert?: ImportAssertions;
+    with?: ImportAssertions;
 }
 
 /**

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5446,7 +5446,8 @@ function isProbablyGlobalType(type: Type, sourceFile: SourceFile, checker: TypeC
     if (globalSymbol && checker.getTypeOfSymbolAtLocation(globalSymbol, sourceFile) === type) {
         return true;
     }
-    const globalThisSymbol = checker.resolveName("globalThis", /*location*/ undefined, SymbolFlags.Value, /*excludeGlobals*/ false);
+    // deno: provide sourceFile so that it can figure out if it's a node or deno globalThis
+    const globalThisSymbol = checker.resolveName("globalThis", /*location*/ sourceFile, SymbolFlags.Value, /*excludeGlobals*/ false);
     if (globalThisSymbol && checker.getTypeOfSymbolAtLocation(globalThisSymbol, sourceFile) === type) {
         return true;
     }


### PR DESCRIPTION
Remotes:

* origin - https://github.com/dsherret/TypeScript
* denoland - https://github.com/denoland/TypeScript
* upstream - https://github.com/Microsoft/TypeScript

Actions:

1. Closed previous "Upgrade to TS 5.1.6" PR
1. `git checkout upstream/release-5.2` and ensured it was on the commit of the release.
1. `git checkout -b branch_v5.2.2`
1. `git push denoland`
1. `git checkout -b branch_v5.2.2_patch`
1. Integrated new changes to support import attributes
1. Cherry picked changes in branch_v5.1.6_patch
1. `npm install && npx hereby` (to build)
1. Inspected all usages of "globals" and "globalThisSymbol" in checker.ts (being aware that `globalThisType` might refer to the global `this` type and not the global `globalThis` type)
1. Ran `gulp local`
1. `cp built/local/typescript.js ../deno/cli/tsc/00_typescript.js`
1. Copied the .d.ts files from `built/local` to `../deno/cli/tsc/dts` as appropriate (all the ones currently in `deno/cli/tsc/dts`).
1. Reviewed this dts files and made any modifications (reverts) necessary
1. Opened this PR with base branch_v5.2.2

https://github.com/denoland/deno/tree/main/cli/tsc#how-to-upgrade-typescript