### PR TITLE
Upgrade to TS 5.5.2

### DIFF
--- a/src/compiler/_namespaces/ts.ts
+++ b/src/compiler/_namespaces/ts.ts
@@ -11,6 +11,7 @@ export * from "../types.js";
 export * from "../sys.js";
 export * from "../path.js";
 export * from "../diagnosticInformationMap.generated.js";
+export * as deno from "../deno.js";
 export * from "../scanner.js";
 export * from "../utilitiesPublic.js";
 export * from "../utilities.js";

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -259,7 +259,7 @@ export namespace BuilderState {
         }
 
         // From ambient modules
-        for (const ambientModule of program.getTypeChecker().getAmbientModules()) {
+        for (const ambientModule of program.getTypeChecker().getAmbientModules(sourceFile)) {
             if (ambientModule.declarations && ambientModule.declarations.length > 1) {
                 addReferenceFromAmbientModule(ambientModule);
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -141,6 +141,7 @@ import {
     defaultMaximumTruncationLength,
     DeferredTypeReference,
     DeleteExpression,
+    deno,
     Diagnostic,
     DiagnosticAndArguments,
     DiagnosticArguments,
@@ -1517,14 +1518,27 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         evaluateEntityNameExpression,
     });
 
-    var globals = createSymbolTable();
+    var denoGlobals = createSymbolTable();
+    var nodeGlobals = createSymbolTable();
     var undefinedSymbol = createSymbol(SymbolFlags.Property, "undefined" as __String);
     undefinedSymbol.declarations = [];
 
-    var globalThisSymbol = createSymbol(SymbolFlags.Module, "globalThis" as __String, CheckFlags.Readonly);
-    globalThisSymbol.exports = globals;
-    globalThisSymbol.declarations = [];
-    globals.set(globalThisSymbol.escapedName, globalThisSymbol);
+    var denoGlobalThisSymbol = createSymbol(SymbolFlags.Module, "globalThis" as __String, CheckFlags.Readonly);
+    denoGlobalThisSymbol.exports = denoGlobals;
+    denoGlobalThisSymbol.declarations = [];
+    denoGlobals.set(denoGlobalThisSymbol.escapedName, denoGlobalThisSymbol);
+
+    const denoContext = deno.createDenoForkContext({
+        globals: denoGlobals,
+        nodeGlobals,
+        mergeSymbol,
+        ambientModuleSymbolRegex,
+    });
+
+    const nodeGlobalThisSymbol = createSymbol(SymbolFlags.Module, "globalThis" as __String, CheckFlags.Readonly);
+    nodeGlobalThisSymbol.exports = denoContext.combinedGlobals;
+    nodeGlobalThisSymbol.declarations = [];
+    nodeGlobals.set(nodeGlobalThisSymbol.escapedName, nodeGlobalThisSymbol);
 
     var argumentsSymbol = createSymbol(SymbolFlags.Property, "arguments" as __String);
     var requireSymbol = createSymbol(SymbolFlags.Property, "require" as __String);
@@ -1542,7 +1556,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         compilerOptions,
         requireSymbol,
         argumentsSymbol,
-        globals,
+        denoGlobals,
+        nodeGlobals,
+        denoContext,
         getSymbolOfDeclaration,
         error,
         getRequiresScopeChangeCache,
@@ -1557,7 +1573,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         compilerOptions,
         requireSymbol,
         argumentsSymbol,
-        globals,
+        denoGlobals,
+        nodeGlobals,
+        denoContext,
         getSymbolOfDeclaration,
         error,
         getRequiresScopeChangeCache,
@@ -2194,6 +2212,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var amalgamatedDuplicates: Map<string, DuplicateInfoForFiles> | undefined;
     var reverseMappedCache = new Map<string, Type | undefined>();
     var ambientModulesCache: Symbol[] | undefined;
+    var nodeAmbientModulesCache: Symbol[] | undefined;
     /**
      * List of every ambient module with a "*" wildcard.
      * Unlike other ambient modules, these can't be stored in `globals` because symbol tables only deal with exact matches.
@@ -2659,7 +2678,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Do not report an error when merging `var globalThis` with the built-in `globalThis`,
             // as we will already report a "Declaration name conflicts..." error, and this error
             // won't make much sense.
-            if (target !== globalThisSymbol) {
+            if (target !== denoGlobalThisSymbol && target !== nodeGlobalThisSymbol) {
                 error(
                     source.declarations && getNameOfDeclaration(source.declarations[0]),
                     Diagnostics.Cannot_augment_module_0_with_value_exports_because_it_resolves_to_a_non_module_entity,
@@ -2756,7 +2775,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (isGlobalScopeAugmentation(moduleAugmentation)) {
-            mergeSymbolTable(globals, moduleAugmentation.symbol.exports!);
+            denoContext.mergeGlobalSymbolTable(moduleAugmentation, moduleAugmentation.symbol.exports!);
         }
         else {
             // find a module that about to be augmented
@@ -2806,17 +2825,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function addUndefinedToGlobalsOrErrorOnRedeclaration() {
         const name = undefinedSymbol.escapedName;
-        const targetSymbol = globals.get(name);
-        if (targetSymbol) {
-            forEach(targetSymbol.declarations, declaration => {
-                // checkTypeNameIsReserved will have added better diagnostics for type declarations.
-                if (!isTypeDeclaration(declaration)) {
-                    diagnostics.add(createDiagnosticForNode(declaration, Diagnostics.Declaration_name_conflicts_with_built_in_global_identifier_0, unescapeLeadingUnderscores(name)));
-                }
-            });
-        }
-        else {
-            globals.set(name, undefinedSymbol);
+        for (const globals of [nodeGlobals, denoGlobals]) {
+            const targetSymbol = globals.get(name);
+            if (targetSymbol) {
+                forEach(targetSymbol.declarations, declaration => {
+                    // checkTypeNameIsReserved will have added better diagnostics for type declarations.
+                    if (!isTypeDeclaration(declaration)) {
+                        diagnostics.add(createDiagnosticForNode(declaration, Diagnostics.Declaration_name_conflicts_with_built_in_global_identifier_0, unescapeLeadingUnderscores(name)));
+                    }
+                });
+            }
+            else {
+                globals.set(name, undefinedSymbol);
+            }
         }
     }
 
@@ -3243,7 +3264,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Look at 'compilerOptions.isolatedModules' and not 'getIsolatedModules(...)' (which considers 'verbatimModuleSyntax')
             // here because 'verbatimModuleSyntax' will already have an error for importing a type without 'import type'.
             if (compilerOptions.isolatedModules && result && isInExternalModule && (meaning & SymbolFlags.Value) === SymbolFlags.Value) {
-                const isGlobal = getSymbol(globals, name, meaning) === result;
+                const isNodeFile = denoContext.hasNodeSourceFile(lastLocation);
+                const fileGlobals = isNodeFile ? nodeGlobals : denoGlobals;
+                const isGlobal = getSymbol(fileGlobals, name, meaning) === result;
                 const nonValueSymbol = isGlobal && isSourceFile(lastLocation) && lastLocation.locals && getSymbol(lastLocation.locals, name, ~SymbolFlags.Value);
                 if (nonValueSymbol) {
                     const importDecl = nonValueSymbol.declarations?.find(d => d.kind === SyntaxKind.ImportSpecifier || d.kind === SyntaxKind.ImportClause || d.kind === SyntaxKind.NamespaceImport || d.kind === SyntaxKind.ImportEqualsDeclaration);
@@ -3652,9 +3675,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function canHaveSyntheticDefault(file: SourceFile | undefined, moduleSymbol: Symbol, dontResolveAlias: boolean, usage: Expression) {
         const usageMode = file && getUsageModeForExpression(usage);
-        if (file && usageMode !== undefined && ModuleKind.Node16 <= moduleKind && moduleKind <= ModuleKind.NodeNext) {
+        // deno: change the condition here to not be dependent on the global module resolution setting, but just the impliedNodeFormat
+        if (file && usageMode !== undefined && file.impliedNodeFormat === ModuleKind.CommonJS) {
             const result = isESMFormatImportImportingCommonjsFormatFile(usageMode, file.impliedNodeFormat);
-            if (usageMode === ModuleKind.ESNext || result) {
+            // deno: removed condition in typescript here (https://github.com/microsoft/TypeScript/issues/51321)
+            if (result) {
                 return result;
             }
             // fallthrough on cjs usages so we imply defaults for interop'd imports, too
@@ -4530,6 +4555,25 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function resolveExternalModule(location: Node, moduleReference: string, moduleNotFoundError: DiagnosticMessage | undefined, errorNode: Node, isForAugmentation = false): Symbol | undefined {
+        const result = resolveExternalModuleInner(location, moduleReference, moduleNotFoundError, errorNode, isForAugmentation);
+
+        // deno: attempt to resolve an npm package reference to its bare specifier w/ path ambient module
+        // when not found and the symbol has zero exports
+        if (moduleReference.startsWith("npm:") && (result === undefined || result?.exports?.size === 0)) {
+            const npmPackageRef = deno.tryParseNpmPackageReference(moduleReference);
+            if (npmPackageRef) {
+                const bareSpecifier = npmPackageRef.name + (npmPackageRef.subPath === undefined ? "" : "/" + npmPackageRef.subPath);
+                const ambientModule = tryFindAmbientModule(bareSpecifier, /*withAugmentations*/ true);
+                if (ambientModule) {
+                    return ambientModule;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    function resolveExternalModuleInner(location: Node, moduleReference: string, moduleNotFoundError: DiagnosticMessage | undefined, errorNode: Node, isForAugmentation = false): Symbol | undefined {
         if (startsWith(moduleReference, "@types/")) {
             const diag = Diagnostics.Cannot_import_type_declaration_files_Consider_importing_0_instead_of_1;
             const withoutAtTypePrefix = removePrefix(moduleReference, "@types/");
@@ -5454,7 +5498,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
 
-        return callback(globals, /*ignoreQualification*/ undefined, /*isLocalNameLookup*/ true);
+        if (denoContext.hasNodeSourceFile(enclosingDeclaration)) {
+            result = callback(nodeGlobals, /*ignoreQualification*/ undefined, /*isLocalNameLookup*/ true);
+            if (result) {
+                return result;
+            }
+        }
+
+        return callback(denoGlobals, /*ignoreQualification*/ undefined, /*isLocalNameLookup*/ true);
     }
 
     function getQualifiedLeftMeaning(rightMeaning: SymbolFlags) {
@@ -5548,7 +5599,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             });
 
             // If there's no result and we're looking at the global symbol table, treat `globalThis` like an alias and try to lookup thru that
-            return result || (symbols === globals ? getCandidateListForSymbol(globalThisSymbol, globalThisSymbol, ignoreQualification) : undefined);
+            if (result) {
+                return result;
+            }
+            const globalSymbol = symbols === nodeGlobals ? nodeGlobalThisSymbol : symbols === denoGlobals ? denoGlobalThisSymbol : undefined;
+            return globalSymbol !== undefined ? getCandidateListForSymbol(globalSymbol, globalSymbol, ignoreQualification) : undefined;
         }
 
         function getCandidateListForSymbol(symbolFromSymbolTable: Symbol, resolvedImportedSymbol: Symbol, ignoreQualification: boolean | undefined) {
@@ -13968,7 +14023,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Combinations of function, class, enum and module
         let members = getExportsOfSymbol(symbol);
         let indexInfos: IndexInfo[] | undefined;
-        if (symbol === globalThisSymbol) {
+        if (symbol === denoGlobalThisSymbol || symbol === nodeGlobalThisSymbol) {
             const varsOnly = new Map<__String, Symbol>();
             members.forEach(p => {
                 if (!(p.flags & SymbolFlags.BlockScoped) && !(p.flags & SymbolFlags.ValueModule && p.declarations?.length && every(p.declarations, isAmbientModule))) {
@@ -15416,7 +15471,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isExternalModuleNameRelative(moduleName)) {
             return undefined;
         }
-        const symbol = getSymbol(globals, '"' + moduleName + '"' as __String, SymbolFlags.ValueModule);
+        const symbol = getSymbol(denoContext.combinedGlobals, '"' + moduleName + '"' as __String, SymbolFlags.ValueModule);
         // merged symbol is module declaration symbol combined with all augmentations
         return symbol && withAugmentations ? getMergedSymbol(symbol) : symbol;
     }
@@ -18615,7 +18670,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
 
-                if (objectType.symbol === globalThisSymbol && propName !== undefined && globalThisSymbol.exports!.has(propName) && (globalThisSymbol.exports!.get(propName)!.flags & SymbolFlags.BlockScoped)) {
+                if (objectType.symbol === denoGlobalThisSymbol && propName !== undefined && denoGlobalThisSymbol.exports!.has(propName) && (denoGlobalThisSymbol.exports!.get(propName)!.flags & SymbolFlags.BlockScoped)) {
+                    error(accessExpression, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(propName), typeToString(objectType));
+                }
+                // deno: ensure condition and body match the above
+                else if (objectType.symbol === nodeGlobalThisSymbol && propName !== undefined && nodeGlobalThisSymbol.exports!.has(propName) && (nodeGlobalThisSymbol.exports!.get(propName)!.flags & SymbolFlags.BlockScoped)) {
                     error(accessExpression, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(propName), typeToString(objectType));
                 }
                 else if (noImplicitAny && !(accessFlags & AccessFlags.SuppressNoImplicitAnyError)) {
@@ -29843,7 +29902,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!location.parent.parent.moduleSpecifier && !location.isTypeOnly && !location.parent.parent.isTypeOnly) {
             const exportedName = location.propertyName || location.name;
             const symbol = resolveName(exportedName, exportedName.escapedText, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias, /*nameNotFoundMessage*/ undefined, /*isUse*/ true);
-            if (symbol && (symbol === undefinedSymbol || symbol === globalThisSymbol || symbol.declarations && isGlobalSourceFile(getDeclarationContainer(symbol.declarations[0])))) {
+            if (symbol && (symbol === undefinedSymbol || symbol === denoGlobalThisSymbol || symbol === nodeGlobalThisSymbol || symbol.declarations && isGlobalSourceFile(getDeclarationContainer(symbol.declarations[0])))) {
                 // Do nothing, non-local symbol
             }
             else {
@@ -30553,8 +30612,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         const type = tryGetThisTypeAt(node, /*includeGlobalThis*/ true, container);
         if (noImplicitThis) {
-            const globalThisType = getTypeOfSymbol(globalThisSymbol);
-            if (type === globalThisType && capturedByArrowFunction) {
+            const globalThisType = getTypeOfSymbol(denoGlobalThisSymbol);
+            if ((type === globalThisType || type === getTypeOfSymbol(nodeGlobalThisSymbol)) && capturedByArrowFunction) {
                 error(node, Diagnostics.The_containing_arrow_function_captures_the_global_value_of_this);
             }
             else if (!type) {
@@ -30616,7 +30675,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return undefinedType;
             }
             else if (includeGlobalThis) {
-                return getTypeOfSymbol(globalThisSymbol);
+                if (denoContext.hasNodeSourceFile(container)) {
+                    return getTypeOfSymbol(nodeGlobalThisSymbol);
+                }
+                return getTypeOfSymbol(denoGlobalThisSymbol);
             }
         }
     }
@@ -33910,13 +33972,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!isUncheckedJS && isJSLiteralType(leftType)) {
                     return anyType;
                 }
-                if (leftType.symbol === globalThisSymbol) {
-                    if (globalThisSymbol.exports!.has(right.escapedText) && (globalThisSymbol.exports!.get(right.escapedText)!.flags & SymbolFlags.BlockScoped)) {
+                if (leftType.symbol === denoGlobalThisSymbol) {
+                    if (denoGlobalThisSymbol.exports!.has(right.escapedText) && (denoGlobalThisSymbol.exports!.get(right.escapedText)!.flags & SymbolFlags.BlockScoped)) {
                         error(right, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(right.escapedText), typeToString(leftType));
                     }
                     else if (noImplicitAny) {
                         error(right, Diagnostics.Element_implicitly_has_an_any_type_because_type_0_has_no_index_signature, typeToString(leftType));
                     }
+                    return anyType;
+                }
+                // deno: ensure condition matches above
+                if (leftType.symbol === nodeGlobalThisSymbol) {
+                    // deno: don't bother with errors like above for simplicity
                     return anyType;
                 }
                 if (right.escapedText && !checkAndReportErrorForExtendingInterface(node)) {
@@ -34251,7 +34318,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // However, resolveNameHelper will continue and call this callback again, so we'll eventually get a correct suggestion.
         if (symbol) return symbol;
         let candidates: Symbol[];
-        if (symbols === globals) {
+        if (symbols === denoGlobals || symbols == nodeGlobals) {
             const primitives = mapDefined(
                 ["string", "number", "boolean", "object", "bigint", "symbol"],
                 s => symbols.has((s.charAt(0).toUpperCase() + s.slice(1)) as __String)
@@ -47194,7 +47261,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const exportedName = node.propertyName || node.name;
             // find immediate value referenced by exported name (SymbolFlags.Alias is set so we don't chase down aliases)
             const symbol = resolveName(exportedName, exportedName.escapedText, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias, /*nameNotFoundMessage*/ undefined, /*isUse*/ true);
-            if (symbol && (symbol === undefinedSymbol || symbol === globalThisSymbol || symbol.declarations && isGlobalSourceFile(getDeclarationContainer(symbol.declarations[0])))) {
+            if (symbol && (symbol === undefinedSymbol || symbol === denoGlobalThisSymbol || symbol === nodeGlobalThisSymbol || symbol.declarations && isGlobalSourceFile(getDeclarationContainer(symbol.declarations[0])))) {
                 error(exportedName, Diagnostics.Cannot_export_0_Only_local_declarations_can_be_exported_from_a_module, idText(exportedName));
             }
             else {
@@ -47344,8 +47411,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (
                 moduleKind >= ModuleKind.ES2015 &&
                 moduleKind !== ModuleKind.Preserve &&
-                ((node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext) ||
-                    (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))
+                // deno: temporarily disable this one until Deno 2.0 (https://github.com/microsoft/TypeScript/pull/52109)
+                (
+                    /* (node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext) || */
+                    !(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS
+                )
             ) {
                 // export assignment is not supported in es6 modules
                 grammarErrorOnNode(node, Diagnostics.Export_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_export_default_or_another_module_format_instead);
@@ -48049,7 +48119,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 location = location.parent;
             }
 
-            copySymbols(globals, meaning);
+            if (denoContext.hasNodeSourceFile(location)) {
+                copySymbols(nodeGlobals, meaning);
+            }
+
+            copySymbols(denoGlobals, meaning);
         }
 
         /**
@@ -49472,7 +49546,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function hasGlobalName(name: string): boolean {
-        return globals.has(escapeLeadingUnderscores(name));
+        // deno: seems ok not to bother with nodeGlobals here since
+        // this is just a public api function that we don't bother with
+        // NOTICE: Make sure to check that's still the case when upgrading!!
+        return denoGlobals.has(escapeLeadingUnderscores(name));
     }
 
     function getReferencedValueSymbol(reference: Identifier, startInDeclarationContainer?: boolean): Symbol | undefined {
@@ -49784,10 +49861,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         diagnostics.add(createDiagnosticForNode(declaration, Diagnostics.Declaration_name_conflicts_with_built_in_global_identifier_0, "globalThis"));
                     }
                 }
-                mergeSymbolTable(globals, file.locals!);
+                denoContext.mergeGlobalSymbolTable(file, file.locals!);
             }
             if (file.jsGlobalAugmentations) {
-                mergeSymbolTable(globals, file.jsGlobalAugmentations);
+                denoContext.mergeGlobalSymbolTable(file, file.jsGlobalAugmentations);
             }
             if (file.patternAmbientModules && file.patternAmbientModules.length) {
                 patternAmbientModules = concatenate(patternAmbientModules, file.patternAmbientModules);
@@ -49798,9 +49875,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (file.symbol && file.symbol.globalExports) {
                 // Merge in UMD exports with first-in-wins semantics (see #9771)
                 const source = file.symbol.globalExports;
+                const isNodeFile = denoContext.hasNodeSourceFile(file);
                 source.forEach((sourceSymbol, id) => {
-                    if (!globals.has(id)) {
-                        globals.set(id, sourceSymbol);
+                    const envGlobals = isNodeFile ? denoContext.getGlobalsForName(id) : denoGlobals;
+                    if (!envGlobals.has(id)) {
+                        envGlobals.set(id, sourceSymbol);
                     }
                 });
             }
@@ -49828,7 +49907,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getSymbolLinks(undefinedSymbol).type = undefinedWideningType;
         getSymbolLinks(argumentsSymbol).type = getGlobalType("IArguments" as __String, /*arity*/ 0, /*reportErrors*/ true);
         getSymbolLinks(unknownSymbol).type = errorType;
-        getSymbolLinks(globalThisSymbol).type = createObjectType(ObjectFlags.Anonymous, globalThisSymbol);
+        getSymbolLinks(denoGlobalThisSymbol).type = createObjectType(ObjectFlags.Anonymous, denoGlobalThisSymbol);
+        getSymbolLinks(nodeGlobalThisSymbol).type = createObjectType(ObjectFlags.Anonymous, nodeGlobalThisSymbol);
 
         // Initialize special types
         globalArrayType = getGlobalType("Array" as __String, /*arity*/ 1, /*reportErrors*/ true);
@@ -51746,17 +51826,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return false;
     }
 
-    function getAmbientModules(): Symbol[] {
-        if (!ambientModulesCache) {
-            ambientModulesCache = [];
-            globals.forEach((global, sym) => {
+    function getAmbientModules(sourceFile?: SourceFile): Symbol[] {
+        const isNode = denoContext.hasNodeSourceFile(sourceFile);
+        if (isNode) {
+            if (!nodeAmbientModulesCache) {
+                nodeAmbientModulesCache = getAmbientModules(denoContext.combinedGlobals);
+            }
+            return nodeAmbientModulesCache;
+        }
+        else {
+            if (!ambientModulesCache) {
+                ambientModulesCache = getAmbientModules(denoGlobals);
+            }
+            return ambientModulesCache;
+        }
+
+        function getAmbientModules(envGlobals: SymbolTable) {
+            const result: Symbol[] = [];
+            envGlobals.forEach((global, sym) => {
                 // No need to `unescapeLeadingUnderscores`, an escaped symbol is never an ambient module.
                 if (ambientModuleSymbolRegex.test(sym as string)) {
-                    ambientModulesCache!.push(global);
+                    result.push(global);
                 }
             });
+            return result;
         }
-        return ambientModulesCache;
     }
 
     function checkGrammarImportClause(node: ImportClause): boolean {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -167,6 +167,7 @@ const libEntries: [string, string][] = [
     ["dom", "lib.dom.d.ts"],
     ["dom.iterable", "lib.dom.iterable.d.ts"],
     ["dom.asynciterable", "lib.dom.asynciterable.d.ts"],
+    ["dom.extras", "lib.dom.extras.d.ts"],
     ["webworker", "lib.webworker.d.ts"],
     ["webworker.importscripts", "lib.webworker.importscripts.d.ts"],
     ["webworker.iterable", "lib.webworker.iterable.d.ts"],

--- a/src/compiler/deno.ts
+++ b/src/compiler/deno.ts
@@ -1,0 +1,206 @@
+import * as ts from "./_namespaces/ts";
+
+export type IsNodeSourceFileCallback = (sourceFile: ts.SourceFile) => boolean;
+
+let isNodeSourceFile: IsNodeSourceFileCallback = () => false;
+let nodeBuiltInModuleNames = new Set<string>();
+let nodeOnlyGlobalNames = new Set<ts.__String>();
+
+export function setIsNodeSourceFileCallback(callback: IsNodeSourceFileCallback) {
+    isNodeSourceFile = callback;
+}
+
+export function setNodeBuiltInModuleNames(names: readonly string[]) {
+    nodeBuiltInModuleNames = new Set(names);
+}
+
+export function setNodeOnlyGlobalNames(names: readonly string[]) {
+    nodeBuiltInModuleNames = new Set(names);
+    nodeOnlyGlobalNames = new Set(names) as Set<ts.__String>;
+}
+
+// When upgrading:
+// Inspect all usages of "globals" and "globalThisSymbol" in checker.ts
+//  - Beware that `globalThisType` might refer to the global `this` type
+//    and not the global `globalThis` type
+
+export interface DenoForkContext {
+    hasNodeSourceFile: (node: ts.Node | undefined) => boolean;
+    getGlobalsForName: (id: ts.__String) => ts.SymbolTable;
+    mergeGlobalSymbolTable: (node: ts.Node, source: ts.SymbolTable, unidirectional?: boolean) => void;
+    combinedGlobals: ts.SymbolTable;
+}
+
+export function createDenoForkContext({
+    mergeSymbol,
+    globals,
+    nodeGlobals,
+    ambientModuleSymbolRegex,
+}: {
+    mergeSymbol(target: ts.Symbol, source: ts.Symbol, unidirectional?: boolean): ts.Symbol;
+    globals: ts.SymbolTable;
+    nodeGlobals: ts.SymbolTable;
+    ambientModuleSymbolRegex: RegExp;
+}): DenoForkContext {
+    return {
+        hasNodeSourceFile,
+        getGlobalsForName,
+        mergeGlobalSymbolTable,
+        combinedGlobals: createNodeGlobalsSymbolTable(),
+    };
+
+    function hasNodeSourceFile(node: ts.Node | undefined) {
+        if (!node) return false;
+        const sourceFile = ts.getSourceFileOfNode(node);
+        return isNodeSourceFile(sourceFile);
+    }
+
+    function getGlobalsForName(id: ts.__String) {
+        // Node ambient modules are only accessible in the node code,
+        // so put them on the node globals
+        if (ambientModuleSymbolRegex.test(id as string)) {
+            if ((id as string).startsWith('"node:')) {
+                // check if it's a node specifier that we support
+                const name = (id as string).slice(6, -1);
+                if (nodeBuiltInModuleNames.has(name)) {
+                    return globals;
+                }
+            }
+            return nodeGlobals;
+        }
+        return nodeOnlyGlobalNames.has(id) ? nodeGlobals : globals;
+    }
+
+    function mergeGlobalSymbolTable(node: ts.Node, source: ts.SymbolTable, unidirectional = false) {
+        const sourceFile = ts.getSourceFileOfNode(node);
+        const isNodeFile = hasNodeSourceFile(sourceFile);
+        source.forEach((sourceSymbol, id) => {
+            const target = isNodeFile ? getGlobalsForName(id) : globals;
+            const targetSymbol = target.get(id);
+            target.set(id, targetSymbol ? mergeSymbol(targetSymbol, sourceSymbol, unidirectional) : sourceSymbol);
+        });
+    }
+
+    function createNodeGlobalsSymbolTable() {
+        return new Proxy(globals, {
+            get(target, prop: string | symbol, receiver) {
+                if (prop === "get") {
+                    return (key: ts.__String) => {
+                        return nodeGlobals.get(key) ?? globals.get(key);
+                    };
+                }
+                else if (prop === "has") {
+                    return (key: ts.__String) => {
+                        return nodeGlobals.has(key) || globals.has(key);
+                    };
+                }
+                else if (prop === "size") {
+                    let i = 0;
+                    for (const _ignore of getEntries(entry => entry)) {
+                        i++;
+                    }
+                    return i;
+                }
+                else if (prop === "forEach") {
+                    return (action: (value: ts.Symbol, key: ts.__String) => void) => {
+                        for (const [key, value] of getEntries(entry => entry)) {
+                            action(value, key);
+                        }
+                    };
+                }
+                else if (prop === "entries") {
+                    return () => {
+                        return getEntries(kv => kv);
+                    };
+                }
+                else if (prop === "keys") {
+                    return () => {
+                        return getEntries(kv => kv[0]);
+                    };
+                }
+                else if (prop === "values") {
+                    return () => {
+                        return getEntries(kv => kv[1]);
+                    };
+                }
+                else if (prop === Symbol.iterator) {
+                    return () => {
+                        // Need to convert this to an array since typescript targets ES5
+                        // and providing back the iterator won't work here. I don't want
+                        // to change the target to ES6 because I'm not sure if that would
+                        // surface any issues.
+                        return Array.from(getEntries(kv => kv))[Symbol.iterator]();
+                    };
+                }
+                else {
+                    const value = (target as any)[prop];
+                    if (value instanceof Function) {
+                        return function (this: any, ...args: any[]) {
+                            return value.apply(this === receiver ? target : this, args);
+                        };
+                    }
+                    return value;
+                }
+            },
+        });
+
+        function* getEntries<R>(
+            transform: (value: [ts.__String, ts.Symbol]) => R,
+        ) {
+            const foundKeys = new Set<ts.__String>();
+            // prefer the node globals over the deno globalThis
+            for (const entries of [nodeGlobals.entries(), globals.entries()]) {
+                for (const entry of entries) {
+                    if (!foundKeys.has(entry[0])) {
+                        yield transform(entry);
+                        foundKeys.add(entry[0]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+export interface NpmPackageReference {
+    name: string;
+    versionReq: string;
+    subPath: string | undefined;
+}
+
+export function tryParseNpmPackageReference(text: string) {
+    try {
+        return parseNpmPackageReference(text);
+    }
+    catch {
+        return undefined;
+    }
+}
+
+export function parseNpmPackageReference(text: string) {
+    if (!text.startsWith("npm:")) {
+        throw new Error(`Not an npm specifier: ${text}`);
+    }
+    text = text.replace(/^npm:\/?/, ""); // todo: remove this regex
+    const parts = text.split("/");
+    const namePartLen = text.startsWith("@") ? 2 : 1;
+    if (parts.length < namePartLen) {
+        throw new Error(`Not a valid package: ${text}`);
+    }
+    const nameParts = parts.slice(0, namePartLen);
+    const lastNamePart = nameParts.at(-1)!;
+    const lastAtIndex = lastNamePart.lastIndexOf("@");
+    let versionReq: string | undefined;
+    if (lastAtIndex > 0) {
+        versionReq = lastNamePart.substring(lastAtIndex + 1);
+        nameParts[nameParts.length - 1] = lastNamePart.substring(0, lastAtIndex);
+    }
+    const name = nameParts.join("/");
+    if (name.length === 0) {
+        throw new Error(`Npm specifier did not have a name: ${text}`);
+    }
+    return {
+        name,
+        versionReq,
+        subPath: parts.length > nameParts.length ? parts.slice(nameParts.length).join("/") : undefined,
+    };
+}

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -216,6 +216,11 @@ function getEncodedRootLength(path: string): number {
         return ~path.length; // URL: "file://server", "http://server"
     }
 
+    // deno: temporary hack until https://github.com/microsoft/TypeScript/issues/53605 is fixed
+    if (path.startsWith("data:")) {
+        return ~path.length;
+    }
+
     // relative
     return 0;
 }
@@ -706,6 +711,11 @@ export function ensureTrailingDirectorySeparator(path: string): string;
 /** @internal */
 export function ensureTrailingDirectorySeparator(path: string) {
     if (!hasTrailingDirectorySeparator(path)) {
+        // deno: added this so that data urls don't get a trailing slash
+        // https://github.com/microsoft/TypeScript/issues/53605#issuecomment-1492167313
+        if (path.startsWith("data:")) {
+            return path;
+        }
         return path + directorySeparator;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5097,7 +5097,7 @@ export interface TypeChecker {
     /** @internal */ forEachExportAndPropertyOfModule(moduleSymbol: Symbol, cb: (symbol: Symbol, key: __String) => void): void;
     getJsxIntrinsicTagNamesAt(location: Node): Symbol[];
     isOptionalParameter(node: ParameterDeclaration): boolean;
-    getAmbientModules(): Symbol[];
+    getAmbientModules(sourceFile?: SourceFile): Symbol[];
 
     tryGetMemberInModuleExports(memberName: string, moduleSymbol: Symbol): Symbol | undefined;
     /**

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -90,6 +90,7 @@ import {
     DeclarationWithTypeParameters,
     Decorator,
     DefaultClause,
+    deno,
     DestructuringAssignment,
     Diagnostic,
     DiagnosticArguments,
@@ -11031,7 +11032,9 @@ export function createNameResolver({
     argumentsSymbol,
     error,
     getSymbolOfDeclaration,
-    globals,
+    denoGlobals,
+    nodeGlobals,
+    denoContext,
     lookup,
     setRequiresScopeChangeCache = returnUndefined,
     getRequiresScopeChangeCache = returnUndefined,
@@ -11042,7 +11045,9 @@ export function createNameResolver({
     compilerOptions: CompilerOptions;
     getSymbolOfDeclaration: (node: Declaration) => Symbol;
     error: (location: Node | undefined, message: DiagnosticMessage, ...args: DiagnosticArguments) => void;
-    globals: SymbolTable;
+    denoGlobals: SymbolTable;
+    nodeGlobals: SymbolTable;
+    denoContext: deno.DenoForkContext;
     argumentsSymbol: Symbol;
     requireSymbol: Symbol;
     lookup: (symbols: SymbolTable, name: __String, meaning: SymbolFlags) => Symbol | undefined;
@@ -11439,7 +11444,12 @@ export function createNameResolver({
             }
 
             if (!excludeGlobals) {
-                result = lookup(globals, name, meaning);
+                if (denoContext.hasNodeSourceFile(lastLocation)) {
+                    result = lookup(nodeGlobals, name, meaning);
+                }
+                if (!result) {
+                    result = lookup(denoGlobals, name, meaning);
+                }
             }
         }
         if (!result) {

--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -269,7 +269,7 @@ declare namespace Intl {
     }
 
     interface DateTimeFormatOptions {
-        calendar?: string | undefined;
+        calendar?: string | (typeof globalThis extends { Temporal: { CalendarProtocol: infer T; }; } ? T : undefined) | undefined;
         dayPeriod?: "narrow" | "short" | "long" | undefined;
         numberingSystem?: string | undefined;
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4490,7 +4490,7 @@ declare namespace Intl {
         timeZoneName?: "short" | "long" | "shortOffset" | "longOffset" | "shortGeneric" | "longGeneric" | undefined;
         formatMatcher?: "best fit" | "basic" | undefined;
         hour12?: boolean | undefined;
-        timeZone?: string | undefined;
+        timeZone?: string | (typeof globalThis extends { Temporal: { TimeZoneProtocol: infer T; }; } ? T : undefined) | undefined;
     }
 
     interface ResolvedDateTimeFormatOptions {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5641,7 +5641,8 @@ function isProbablyGlobalType(type: Type, sourceFile: SourceFile, checker: TypeC
     if (globalSymbol && checker.getTypeOfSymbolAtLocation(globalSymbol, sourceFile) === type) {
         return true;
     }
-    const globalThisSymbol = checker.resolveName("globalThis", /*location*/ undefined, SymbolFlags.Value, /*excludeGlobals*/ false);
+    // deno: provide sourceFile so that it can figure out if it's a node or deno globalThis
+    const globalThisSymbol = checker.resolveName("globalThis", /*location*/ sourceFile, SymbolFlags.Value, /*excludeGlobals*/ false);
     if (globalThisSymbol && checker.getTypeOfSymbolAtLocation(globalThisSymbol, sourceFile) === type) {
         return true;
     }


### PR DESCRIPTION
Remotes:

* origin - https://github.com/dsherret/TypeScript
* denoland - https://github.com/denoland/TypeScript
* upstream - https://github.com/Microsoft/TypeScript

Actions:

1. Closed previous "Upgrade to TS 5.4.5" PR
1. `git fetch upstream`
1. `git checkout upstream/release-5.5` and ensured it was on the commit of the release.
1. `git checkout -b branch_v5.5.2`
1. `git push denoland`
1. `git checkout -b branch_v5.5.2_patch`
1. Cherry picked changes in from `origin/branch_5.4.5_patch` into `origin/branch_v5.5.2_patch` and squashed the commits
1. `npm install && npx hereby` (to build)
   - If you get a diagnostic about `globals` or `globalThisSymbol` not existing, it's because they're called `denoGlobals`/`nodeGlobals` and `denoGlobalThisSymbol`/`nodeGlobalThisSymbol` in this fork
   - If there are new usages of `globals` or `globalThisSymbol` in checker.ts, update that code to be properly handled using either `denoGlobals`/`nodeGlobals` or `denoGlobalThisSymbol`/`nodeGlobalThisSymbol` (note: `globalThisType` refers to the global `this` type and not the global `globalThis` type)
1. `cp built/local/typescript.js ../deno/cli/tsc/00_typescript.js`
1. Copied the .d.ts files from `built/local` to `../deno/cli/tsc/dts` then deleted files that didn't seem necessary (ex. typescript.internal.d.ts).
1. Reviewed the dts files and made any modifications (reverts) necessary
1. Search for "5.4.5" in the Deno codebase and replace with the new version
1. Check if `ScriptElementKind` in the ts codebase has changed and if so, align with `ScriptElementKind` in cli/lsp/tsc.rs
1. Ran `cargo test check` and `cargo test lsp`
1. Opened this PR with base branch_v5.5.2 from denoland repo

https://github.com/denoland/deno/tree/main/cli/tsc#how-to-upgrade-typescript