### PR TITLE
Upgrade to TS 5.7.2

### DIFF
--- a/src/compiler/_namespaces/ts.ts
+++ b/src/compiler/_namespaces/ts.ts
@@ -10,6 +10,7 @@ export * from "../types.js";
 export * from "../sys.js";
 export * from "../path.js";
 export * from "../diagnosticInformationMap.generated.js";
+export * as deno from "../deno.js";
 export * from "../scanner.js";
 export * from "../utilitiesPublic.js";
 export * from "../utilities.js";

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -260,7 +260,7 @@ export namespace BuilderState {
         }
 
         // From ambient modules
-        for (const ambientModule of program.getTypeChecker().getAmbientModules()) {
+        for (const ambientModule of program.getTypeChecker().getAmbientModules(sourceFile)) {
             if (ambientModule.declarations && ambientModule.declarations.length > 1) {
                 addReferenceFromAmbientModule(ambientModule);
             }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -169,6 +169,7 @@ const libEntries: [string, string][] = [
     ["dom", "lib.dom.d.ts"],
     ["dom.iterable", "lib.dom.iterable.d.ts"],
     ["dom.asynciterable", "lib.dom.asynciterable.d.ts"],
+    ["dom.extras", "lib.dom.extras.d.ts"],
     ["webworker", "lib.webworker.d.ts"],
     ["webworker.importscripts", "lib.webworker.importscripts.d.ts"],
     ["webworker.iterable", "lib.webworker.iterable.d.ts"],

--- a/src/compiler/deno.ts
+++ b/src/compiler/deno.ts
@@ -1,0 +1,186 @@
+import * as ts from "./_namespaces/ts";
+
+export type IsNodeSourceFileCallback = (sourceFile: ts.SourceFile) => boolean;
+
+let isNodeSourceFile: IsNodeSourceFileCallback = () => false;
+let nodeOnlyGlobalNames = new Set<ts.__String>();
+
+export function setIsNodeSourceFileCallback(callback: IsNodeSourceFileCallback) {
+    isNodeSourceFile = callback;
+}
+
+export function setNodeOnlyGlobalNames(names: readonly string[]) {
+    nodeOnlyGlobalNames = new Set(names) as Set<ts.__String>;
+}
+
+// When upgrading:
+// Inspect all usages of "globals" and "globalThisSymbol" in checker.ts
+//  - Beware that `globalThisType` might refer to the global `this` type
+//    and not the global `globalThis` type
+
+export interface DenoForkContext {
+    hasNodeSourceFile: (node: ts.Node | undefined) => boolean;
+    getGlobalsForName: (id: ts.__String) => ts.SymbolTable;
+    mergeGlobalSymbolTable: (node: ts.Node, source: ts.SymbolTable, unidirectional?: boolean) => void;
+    combinedGlobals: ts.SymbolTable;
+}
+
+export function createDenoForkContext({
+    mergeSymbol,
+    globals,
+    nodeGlobals,
+}: {
+    mergeSymbol(target: ts.Symbol, source: ts.Symbol, unidirectional?: boolean): ts.Symbol;
+    globals: ts.SymbolTable;
+    nodeGlobals: ts.SymbolTable;
+}): DenoForkContext {
+    return {
+        hasNodeSourceFile,
+        getGlobalsForName,
+        mergeGlobalSymbolTable,
+        combinedGlobals: createNodeGlobalsSymbolTable(),
+    };
+
+    function hasNodeSourceFile(node: ts.Node | undefined) {
+        if (!node) return false;
+        const sourceFile = ts.getSourceFileOfNode(node);
+        return isNodeSourceFile(sourceFile);
+    }
+
+    function getGlobalsForName(id: ts.__String) {
+        return nodeOnlyGlobalNames.has(id) ? nodeGlobals : globals;
+    }
+
+    function mergeGlobalSymbolTable(node: ts.Node, source: ts.SymbolTable, unidirectional = false) {
+        const sourceFile = ts.getSourceFileOfNode(node);
+        const isNodeFile = hasNodeSourceFile(sourceFile);
+        source.forEach((sourceSymbol, id) => {
+            const target = isNodeFile ? getGlobalsForName(id) : globals;
+            const targetSymbol = target.get(id);
+            target.set(id, targetSymbol ? mergeSymbol(targetSymbol, sourceSymbol, unidirectional) : sourceSymbol);
+        });
+    }
+
+    function createNodeGlobalsSymbolTable() {
+        return new Proxy(globals, {
+            get(target, prop: string | symbol, receiver) {
+                if (prop === "get") {
+                    return (key: ts.__String) => {
+                        return nodeGlobals.get(key) ?? globals.get(key);
+                    };
+                }
+                else if (prop === "has") {
+                    return (key: ts.__String) => {
+                        return nodeGlobals.has(key) || globals.has(key);
+                    };
+                }
+                else if (prop === "size") {
+                    let i = 0;
+                    for (const _ignore of getEntries(entry => entry)) {
+                        i++;
+                    }
+                    return i;
+                }
+                else if (prop === "forEach") {
+                    return (action: (value: ts.Symbol, key: ts.__String) => void) => {
+                        for (const [key, value] of getEntries(entry => entry)) {
+                            action(value, key);
+                        }
+                    };
+                }
+                else if (prop === "entries") {
+                    return () => {
+                        return getEntries(kv => kv);
+                    };
+                }
+                else if (prop === "keys") {
+                    return () => {
+                        return getEntries(kv => kv[0]);
+                    };
+                }
+                else if (prop === "values") {
+                    return () => {
+                        return getEntries(kv => kv[1]);
+                    };
+                }
+                else if (prop === Symbol.iterator) {
+                    return () => {
+                        // Need to convert this to an array since typescript targets ES5
+                        // and providing back the iterator won't work here. I don't want
+                        // to change the target to ES6 because I'm not sure if that would
+                        // surface any issues.
+                        return Array.from(getEntries(kv => kv))[Symbol.iterator]();
+                    };
+                }
+                else {
+                    const value = (target as any)[prop];
+                    if (value instanceof Function) {
+                        return function (this: any, ...args: any[]) {
+                            return value.apply(this === receiver ? target : this, args);
+                        };
+                    }
+                    return value;
+                }
+            },
+        });
+
+        function* getEntries<R>(
+            transform: (value: [ts.__String, ts.Symbol]) => R,
+        ) {
+            const foundKeys = new Set<ts.__String>();
+            // prefer the node globals over the deno globalThis
+            for (const entries of [nodeGlobals.entries(), globals.entries()]) {
+                for (const entry of entries) {
+                    if (!foundKeys.has(entry[0])) {
+                        yield transform(entry);
+                        foundKeys.add(entry[0]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+export interface NpmPackageReference {
+    name: string;
+    versionReq: string;
+    subPath: string | undefined;
+}
+
+export function tryParseNpmPackageReference(text: string) {
+    try {
+        return parseNpmPackageReference(text);
+    }
+    catch {
+        return undefined;
+    }
+}
+
+export function parseNpmPackageReference(text: string) {
+    if (!text.startsWith("npm:")) {
+        throw new Error(`Not an npm specifier: ${text}`);
+    }
+    text = text.replace(/^npm:\/?/, ""); // todo: remove this regex
+    const parts = text.split("/");
+    const namePartLen = text.startsWith("@") ? 2 : 1;
+    if (parts.length < namePartLen) {
+        throw new Error(`Not a valid package: ${text}`);
+    }
+    const nameParts = parts.slice(0, namePartLen);
+    const lastNamePart = nameParts.at(-1)!;
+    const lastAtIndex = lastNamePart.lastIndexOf("@");
+    let versionReq: string | undefined;
+    if (lastAtIndex > 0) {
+        versionReq = lastNamePart.substring(lastAtIndex + 1);
+        nameParts[nameParts.length - 1] = lastNamePart.substring(0, lastAtIndex);
+    }
+    const name = nameParts.join("/");
+    if (name.length === 0) {
+        throw new Error(`Npm specifier did not have a name: ${text}`);
+    }
+    return {
+        name,
+        versionReq,
+        subPath: parts.length > nameParts.length ? parts.slice(nameParts.length).join("/") : undefined,
+    };
+}

--- a/src/compiler/deno.ts
+++ b/src/compiler/deno.ts
@@ -5,11 +5,11 @@ export type IsNodeSourceFileCallback = (sourceFile: ts.SourceFile) => boolean;
 let isNodeSourceFile: IsNodeSourceFileCallback = () => false;
 let nodeOnlyGlobalNames = new Set<ts.__String>();
 
-export function setIsNodeSourceFileCallback(callback: IsNodeSourceFileCallback) {
+export function setIsNodeSourceFileCallback(callback: IsNodeSourceFileCallback): void {
     isNodeSourceFile = callback;
 }
 
-export function setNodeOnlyGlobalNames(names: readonly string[]) {
+export function setNodeOnlyGlobalNames(names: readonly string[]): void {
     nodeOnlyGlobalNames = new Set(names) as Set<ts.__String>;
 }
 
@@ -143,11 +143,11 @@ export function createDenoForkContext({
 
 export interface NpmPackageReference {
     name: string;
-    versionReq: string;
+    versionReq: string | undefined;
     subPath: string | undefined;
 }
 
-export function tryParseNpmPackageReference(text: string) {
+export function tryParseNpmPackageReference(text: string): NpmPackageReference | undefined {
     try {
         return parseNpmPackageReference(text);
     }
@@ -156,7 +156,7 @@ export function tryParseNpmPackageReference(text: string) {
     }
 }
 
-export function parseNpmPackageReference(text: string) {
+export function parseNpmPackageReference(text: string): NpmPackageReference {
     if (!text.startsWith("npm:")) {
         throw new Error(`Not an npm specifier: ${text}`);
     }

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -216,6 +216,11 @@ function getEncodedRootLength(path: string): number {
         return ~path.length; // URL: "file://server", "http://server"
     }
 
+    // deno: temporary hack until https://github.com/microsoft/TypeScript/issues/53605 is fixed
+    if (path.startsWith("data:")) {
+        return ~path.length;
+    }
+
     // relative
     return 0;
 }
@@ -706,6 +711,11 @@ export function ensureTrailingDirectorySeparator(path: string): string;
 /** @internal */
 export function ensureTrailingDirectorySeparator(path: string) {
     if (!hasTrailingDirectorySeparator(path)) {
+        // deno: added this so that data urls don't get a trailing slash
+        // https://github.com/microsoft/TypeScript/issues/53605#issuecomment-1492167313
+        if (path.startsWith("data:")) {
+            return path;
+        }
         return path + directorySeparator;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5219,7 +5219,7 @@ export interface TypeChecker {
     /** @internal */ forEachExportAndPropertyOfModule(moduleSymbol: Symbol, cb: (symbol: Symbol, key: __String) => void): void;
     getJsxIntrinsicTagNamesAt(location: Node): Symbol[];
     isOptionalParameter(node: ParameterDeclaration): boolean;
-    getAmbientModules(): Symbol[];
+    getAmbientModules(sourceFile?: SourceFile): Symbol[];
 
     tryGetMemberInModuleExports(memberName: string, moduleSymbol: Symbol): Symbol | undefined;
     /**

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -91,6 +91,7 @@ import {
     DeclarationWithTypeParameters,
     Decorator,
     DefaultClause,
+    deno,
     DestructuringAssignment,
     Diagnostic,
     DiagnosticArguments,
@@ -11368,7 +11369,9 @@ export function createNameResolver({
     argumentsSymbol,
     error,
     getSymbolOfDeclaration,
-    globals,
+    denoGlobals,
+    nodeGlobals,
+    denoContext,
     lookup,
     setRequiresScopeChangeCache = returnUndefined,
     getRequiresScopeChangeCache = returnUndefined,
@@ -11751,7 +11754,12 @@ export function createNameResolver({
             }
 
             if (!excludeGlobals) {
-                result = lookup(globals, name, meaning);
+                if (denoContext.hasNodeSourceFile(lastLocation)) {
+                    result = lookup(nodeGlobals, name, meaning);
+                }
+                if (!result) {
+                    result = lookup(denoGlobals, name, meaning);
+                }
             }
         }
         if (!result) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -11341,7 +11341,9 @@ export interface NameResolverOptions {
     compilerOptions: CompilerOptions;
     getSymbolOfDeclaration: (node: Declaration) => Symbol;
     error: (location: Node | undefined, message: DiagnosticMessage, ...args: DiagnosticArguments) => void;
-    globals: SymbolTable;
+    denoGlobals: SymbolTable;
+    nodeGlobals: SymbolTable;
+    denoContext: deno.DenoForkContext;
     argumentsSymbol: Symbol;
     requireSymbol: Symbol;
     lookup: (symbols: SymbolTable, name: __String, meaning: SymbolFlags) => Symbol | undefined;

--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -19105,6 +19105,7 @@ declare var ReadableStream: {
     new(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number }): ReadableStream<Uint8Array>;
     new<R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
+    from<R>(asyncIterable: AsyncIterable<R> | Iterable<R | PromiseLike<R>>): ReadableStream<R>;
 };
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader) */

--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -269,7 +269,7 @@ declare namespace Intl {
     }
 
     interface DateTimeFormatOptions {
-        calendar?: string | undefined;
+        calendar?: string | (typeof globalThis extends { Temporal: { CalendarProtocol: infer T; }; } ? T : undefined) | undefined;
         dayPeriod?: "narrow" | "short" | "long" | undefined;
         numberingSystem?: string | undefined;
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4490,7 +4490,7 @@ declare namespace Intl {
         timeZoneName?: "short" | "long" | "shortOffset" | "longOffset" | "shortGeneric" | "longGeneric" | undefined;
         formatMatcher?: "best fit" | "basic" | undefined;
         hour12?: boolean | undefined;
-        timeZone?: string | undefined;
+        timeZone?: string | (typeof globalThis extends { Temporal: { TimeZoneProtocol: infer T; }; } ? T : undefined) | undefined;
     }
 
     interface ResolvedDateTimeFormatOptions {

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -5093,6 +5093,7 @@ declare var ReadableStream: {
     new(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number }): ReadableStream<Uint8Array>;
     new<R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
+    from<R>(asyncIterable: AsyncIterable<R> | Iterable<R | PromiseLike<R>>): ReadableStream<R>;
 };
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader) */

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5825,7 +5825,8 @@ function isProbablyGlobalType(type: Type, sourceFile: SourceFile, checker: TypeC
     if (globalSymbol && checker.getTypeOfSymbolAtLocation(globalSymbol, sourceFile) === type) {
         return true;
     }
-    const globalThisSymbol = checker.resolveName("globalThis", /*location*/ undefined, SymbolFlags.Value, /*excludeGlobals*/ false);
+    // deno: provide sourceFile so that it can figure out if it's a node or deno globalThis
+    const globalThisSymbol = checker.resolveName("globalThis", /*location*/ sourceFile, SymbolFlags.Value, /*excludeGlobals*/ false);
     if (globalThisSymbol && checker.getTypeOfSymbolAtLocation(globalThisSymbol, sourceFile) === type) {
         return true;
     }


### PR DESCRIPTION
Remotes:

* origin - https://github.com/dsherret/TypeScript
* denoland - https://github.com/denoland/TypeScript
* upstream - https://github.com/Microsoft/TypeScript

Actions:

1. Closed previous "Upgrade to TS 5.6.2” PR
1. `git fetch upstream`
1. `git checkout upstream/release-5.7` and ensured it was on the commit of the release.
1. `git checkout -b branch_v5.7.2`
1. `git push denoland`
1. `git checkout -b branch_v5.7.2_patch`
1. Cherry picked changes in from `denoland/branch_5.6.5_patch` into `denoland/branch_v5.7.2_patch` and squashed the commits
1. `npm install && npx hereby` (to build)
   - If you get a diagnostic about `globals` or `globalThisSymbol` not existing, it's because they're called `denoGlobals`/`nodeGlobals` and `denoGlobalThisSymbol`/`nodeGlobalThisSymbol` in this fork
   - If there are new usages of `globals` or `globalThisSymbol` in checker.ts, update that code to be properly handled using either `denoGlobals`/`nodeGlobals` or `denoGlobalThisSymbol`/`nodeGlobalThisSymbol` (note: `globalThisType` refers to the global `this` type and not the global `globalThis` type)
1. `cp built/local/typescript.js ../deno/cli/tsc/00_typescript.js`
1. Copied the .d.ts files from `built/local` to `../deno/cli/tsc/dts` then deleted files that didn't seem necessary (ex. typescript.internal.d.ts).
1. Reviewed the dts files and made any modifications (reverts) necessary
1. Search for "5.6.2" in the Deno codebase and replace with the new version
1. Check if `ScriptElementKind` in the ts codebase has changed and if so, align with `ScriptElementKind` in cli/lsp/tsc.rs
1. Ran `cargo test check` and `cargo test lsp`
1. Opened this PR with base branch_v5.7.2 from denoland repo

https://github.com/denoland/deno/tree/main/cli/tsc#how-to-upgrade-typescript